### PR TITLE
Added docs for NodeOpener.

### DIFF
--- a/fs/serve.go
+++ b/fs/serve.go
@@ -167,10 +167,12 @@ type NodeMkdirer interface {
 	Mkdir(req *fuse.MkdirRequest, intr Intr) (Node, fuse.Error)
 }
 
+// A NodeOpener knows how to open a handle for the file or directory associated
+// with the node. If the node does not implement NodeOpener, opens will
+// automatically succeed and the node itself will be used as the handle.
 type NodeOpener interface {
 	// Open opens the receiver.
 	// XXX note about access.  XXX OpenFlags.
-	// XXX note that the Node may be a file or directory.
 	Open(req *fuse.OpenRequest, resp *fuse.OpenResponse, intr Intr) (Handle, fuse.Error)
 }
 


### PR DESCRIPTION
In particular, clarified [what happens][ref] if it's not implemented.
[ref]: https://github.com/bazillion/fuse/blob/d62a1291477b51b24becf4def173bd843138c4b6/fs/serve.go#L907