### PR TITLE
Ensure that contexts are always cancelled eventually.

### DIFF
--- a/fs/serve.go
+++ b/fs/serve.go
@@ -624,6 +624,8 @@ func (m *renameNewDirNodeNotFound) String() string {
 
 func (c *serveConn) serve(r fuse.Request) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	req := &serveRequest{Request: r, cancel: cancel}
 
 	c.debug(request{


### PR DESCRIPTION
This is a (newly documented) requirement of context.WithCancel:
    http://godoc.org/golang.org/x/net/context#WithCancel