### PR TITLE
Added a MountOption for default_permissions

### DIFF
--- a/options.go
+++ b/options.go
@@ -107,3 +107,13 @@ func AllowRoot() MountOption {
 		return nil
 	}
 }
+
+// DefaultPermissions tells the FUSE kernel layer to check inode permissions in
+// the usual way before calling the file system, rather than leaving it up to
+// the file system to implement access policies itself.
+func DefaultPermissions() MountOption {
+	return func(conf *MountConfig) error {
+		conf.options["default_permissions"] = ""
+		return nil
+	}
+}


### PR DESCRIPTION
This is necessary to get sane posix permissions behavior from the kernel, without having to implement it yourself for every file system method. At least on Linux.