### PR TITLE
Added a MountOption factory for setting arbitrary key/value pairs.

### DIFF
--- a/options.go
+++ b/options.go
@@ -107,3 +107,13 @@ func AllowRoot() MountOption {
 		return nil
 	}
 }
+
+// Set the supplied arbitrary (key, value) pair in the "-o" argument to the
+// fuse mount binary, overriding any previous setting for the key. If value is
+// empty, the '=' will be omitted from the argument.
+func SetOption(key, value string) MountOption {
+	return func(conf *MountConfig) error {
+		conf.options[key] = value
+		return nil
+	}
+}


### PR DESCRIPTION
This can be used to set arbitrary system-specific mount options without having
to make a code change for each (bazillion/fuse#77).